### PR TITLE
Run the Fontra server in a separate process

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ git+https://github.com/googlefonts/fontra-rcjk.git
 aiohttp==3.8.4
 pyinstaller==5.9.0
 PyQt6==6.4.2
-qasync==0.23.0


### PR DESCRIPTION
- This is easier and possibly faster than using Qt with an async-compatible event loop.
- Remove qasync dependency

This is an alternative to #20.

Confirmed to work on Windows, and it is indeed much faster.