### PR TITLE
Pin PyQt6-Qt6 to previous release: 6.5.0 does not work on 10.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 git+https://github.com/googlefonts/fontra.git
 git+https://github.com/googlefonts/fontra-rcjk.git
 aiohttp==3.8.4
-pyinstaller==5.9.0
+pyinstaller==5.10.0
 PyQt6==6.4.2
+PyQt6-Qt6==6.4.3


### PR DESCRIPTION
This fixes #26.

Turns out PyQt 6.5.0 was to blame, despite it being pinned to 6.4.2.

Upstream report: https://bugreports.qt.io/browse/PYSIDE-2295