### PR TITLE
Upload nightly builds.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -144,6 +144,10 @@ jobs:
           name: "Fontra Pak macOS"
           path: ./downloaded-artifacts-macos
 
+      - name: Unzip macOS Artifact
+        run: |
+          unzip -q ./downloaded-artifact-macos/*.zip -d ./downloaded-artifact-macos
+
       - name: Upload macOS Artifact to Remote Host
         uses: appleboy/scp-action@v0.1.4
         with:
@@ -151,7 +155,7 @@ jobs:
           username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
           password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
           port: 22
-          source: "./downloaded-artifacts-macos/Fontra Pak macOS.zip"
+          source: "./downloaded-artifacts-macos/Fontra Pak macOS.dmg"
           target: "/root/fontra-download/public-html/"
 
       - name: Download Windows Artifact

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -144,24 +144,15 @@ jobs:
           name: "Fontra Pak macOS"
           path: ./downloaded-artifact
 
-      # - name: Upload Artifact
-      #   uses: appleboy/scp-action@v0.1.4
-      #   with:
-      #     host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-      #     username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-      #     password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-      #     port: 22
-      #     source: "./downloaded-artifact/FontraPak.dmg"
-      #     target: "/root/fontra-download/public-html/"
-
       - name: Upload Artifact
-        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
+        uses: appleboy/scp-action@v0.1.4
         with:
-            server: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-            username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-            password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-            local_path: "./downloaded-artifact/FontraPak.dmg"
-            remote_path: "/root/fontra-download/public-html/"
+          host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+          username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+          password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+          port: 22
+          source: "./downloaded-artifact/FontraPak.dmg"
+          target: "/root/fontra-download/public-html/"
 
   upload-windows-exe:
     runs-on: ubuntu-latest
@@ -179,21 +170,12 @@ jobs:
           cd ./downloaded-artifact
           zip -q FontraPak.zip "Fontra Pak.exe"
 
-      # - name: Upload Artifact
-      #   uses: appleboy/scp-action@v0.1.4
-      #   with:
-      #     host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-      #     username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-      #     password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-      #     port: 22
-      #     source: "./downloaded-artifact/FontraPak.zip"
-      #     target: "/root/fontra-download/public-html/"
-
       - name: Upload Artifact
-        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
+        uses: appleboy/scp-action@v0.1.4
         with:
-            server: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-            username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-            password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-            local_path: "./downloaded-artifact/FontraPak.zip"
-            remote_path: "/root/fontra-download/public-html/"
+          host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+          username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+          password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+          port: 22
+          source: "./downloaded-artifact/FontraPak.zip"
+          target: "/root/fontra-download/public-html/"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -101,6 +101,17 @@ jobs:
           name: Fontra Pak macOS
           path: ./dist/*.dmg
 
+      - name: Upload macOS Artifacts
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+          username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+          password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+          port: 22
+          source: "./dist/*.dmg"
+          target: "/root/fontra-download/public-html/"
+        working-directory: ${{ github.workspace }}
+
   build-windows-exe:
     runs-on: windows-latest
 
@@ -132,3 +143,22 @@ jobs:
         with:
           name: Fontra Pak Windows
           path: ./dist/*.exe
+
+      - name: Zip Windows Artifacts
+        run: |
+          cp ./dist/*.exe zip_temp/
+          exe_basename=$(basename ./dist/*.exe)
+          zip -r "$exe_basename.zip" zip_temp/
+          rm -rf zip_temp
+        working-directory: ${{ github.workspace }}
+
+      - name: Upload Windows Artifacts
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+          username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+          password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+          port: 22
+          source: "./dist/*.zip"
+          target: "/root/fontra-download/public-html/"
+        working-directory: ${{ github.workspace }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -102,14 +102,22 @@ jobs:
           path: ./dist/*.dmg
 
       - name: Upload macOS Artifacts
-        uses: appleboy/scp-action@v0.1.4
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
         with:
-          host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-          username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-          password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-          port: 22
-          source: "./dist/*.dmg"
-          target: "/root/fontra-download/public-html/"
+            server: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+            username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+            password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+            local_path: "./dist/*.dmg"
+            remote_path: "/root/fontra-download/public-html/"
+
+        # uses: appleboy/scp-action@v0.1.4
+        # with:
+        #   host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+        #   username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+        #   password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+        #   port: 22
+        #   source: "./dist/*.dmg"
+        #   target: "/root/fontra-download/public-html/"
 
   build-windows-exe:
     runs-on: windows-latest
@@ -150,11 +158,19 @@ jobs:
           dest: "Fontra Pak Windows.zip"
 
       - name: Upload Windows Artifacts
-        uses: appleboy/scp-action@v0.1.4
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
         with:
-          host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-          username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-          password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-          port: 22
-          source: "./dist/*.zip"
-          target: "/root/fontra-download/public-html/"
+            server: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+            username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+            password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+            local_path: "./dist/*.zip"
+            remote_path: "/root/fontra-download/public-html/"
+
+      #   uses: appleboy/scp-action@v0.1.4
+      #   with:
+      #     host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+      #     username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+      #     password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+      #     port: 22
+      #     source: "./dist/*.zip"
+      #     target: "/root/fontra-download/public-html/"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -144,6 +144,11 @@ jobs:
           name: "Fontra Pak macOS"
           path: ./downloaded-artifact
 
+      - name: Debug Artifact
+        run: |
+          ls -l
+          ls -l ./downloaded-artifact
+
       - name: Unzip Artifact
         run: |
           unzip -q "./downloaded-artifact/Fontra Pak macOS.zip" -d ./downloaded-artifact
@@ -168,6 +173,11 @@ jobs:
         with:
           name: "Fontra Pak Windows"
           path: ./downloaded-artifact
+
+      - name: Debug Artifact
+        run: |
+          ls -l
+          ls -l ./downloaded-artifact
 
       - name: Upload Artifact
         uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -144,15 +144,24 @@ jobs:
           name: "Fontra Pak macOS"
           path: ./downloaded-artifact
 
+      # - name: Upload Artifact
+      #   uses: appleboy/scp-action@v0.1.4
+      #   with:
+      #     host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+      #     username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+      #     password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+      #     port: 22
+      #     source: "./downloaded-artifact/FontraPak.dmg"
+      #     target: "/root/fontra-download/public-html/"
+
       - name: Upload Artifact
-        uses: appleboy/scp-action@v0.1.4
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
         with:
-          host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-          username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-          password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-          port: 22
-          source: "./downloaded-artifact/FontraPak.dmg"
-          target: "/root/fontra-download/public-html/"
+            server: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+            username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+            password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+            local_path: "./downloaded-artifact/FontraPak.dmg"
+            remote_path: "/root/fontra-download/public-html/"
 
   upload-windows-exe:
     runs-on: ubuntu-latest
@@ -170,12 +179,21 @@ jobs:
           cd ./downloaded-artifact
           zip -q FontraPak.zip "Fontra Pak.exe"
 
+      # - name: Upload Artifact
+      #   uses: appleboy/scp-action@v0.1.4
+      #   with:
+      #     host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+      #     username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+      #     password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+      #     port: 22
+      #     source: "./downloaded-artifact/FontraPak.zip"
+      #     target: "/root/fontra-download/public-html/"
+
       - name: Upload Artifact
-        uses: appleboy/scp-action@v0.1.4
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
         with:
-          host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-          username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-          password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-          port: 22
-          source: "./downloaded-artifact/FontraPak.zip"
-          target: "/root/fontra-download/public-html/"
+            server: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+            username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+            password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+            local_path: "./downloaded-artifact/FontraPak.zip"
+            remote_path: "/root/fontra-download/public-html/"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -153,9 +153,9 @@ jobs:
           port: 22
           source: "./downloaded-artifact/FontraPak.dmg"
           target: "/home/fontra/public-html/"
+          strip_components: 2
           debug: true
           overwrite: true
-          use_insecure_cipher: true
 
   upload-windows-exe:
     runs-on: ubuntu-latest
@@ -182,6 +182,6 @@ jobs:
           port: 22
           source: "./downloaded-artifact/FontraPak.zip"
           target: "/home/fontra/public-html/"
+          strip_components: 2
           debug: true
           overwrite: true
-          use_insecure_cipher: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -152,7 +152,7 @@ jobs:
           password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
           port: 22
           source: "./downloaded-artifact/FontraPak.dmg"
-          target: "/root/fontra-download/public-html/"
+          target: "/home/fontra/public-html/"
           debug: true
           overwrite: true
           use_insecure_cipher: true
@@ -181,7 +181,7 @@ jobs:
           password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
           port: 22
           source: "./downloaded-artifact/FontraPak.zip"
-          target: "/root/fontra-download/public-html/"
+          target: "/home/fontra/public-html/"
           debug: true
           overwrite: true
           use_insecure_cipher: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -101,24 +101,6 @@ jobs:
           name: Fontra Pak macOS
           path: ./dist/*.dmg
 
-      - name: Upload macOS Artifacts
-        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
-        with:
-            server: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-            username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-            password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-            local_path: "./dist/*.dmg"
-            remote_path: "/root/fontra-download/public-html/"
-
-        # uses: appleboy/scp-action@v0.1.4
-        # with:
-        #   host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-        #   username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-        #   password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-        #   port: 22
-        #   source: "./dist/*.dmg"
-        #   target: "/root/fontra-download/public-html/"
-
   build-windows-exe:
     runs-on: windows-latest
 
@@ -151,26 +133,29 @@ jobs:
           name: Fontra Pak Windows
           path: ./dist/*.exe
 
-      - name: Zip Windows Artifacts
-        uses: vimtor/action-zip@v1.1
-        with:
-          files: ./dist/Fontra Pak Windows.exe
-          dest: "Fontra Pak Windows.zip"
+  upload:
+    runs-on: ubuntu-latest
+    needs: [build-macos-app, build-windows-exe]
+    steps:
 
-      - name: Upload Windows Artifacts
-        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
+      - name: Download macOS Artifact
+        uses: actions/download-artifact@v2
         with:
-            server: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-            username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-            password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-            local_path: "./dist/*.zip"
-            remote_path: "/root/fontra-download/public-html/"
+          name: "Fontra Pak macOS"
+          path: ./downloaded-artifacts
 
-      #   uses: appleboy/scp-action@v0.1.4
-      #   with:
-      #     host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
-      #     username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
-      #     password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
-      #     port: 22
-      #     source: "./dist/*.zip"
-      #     target: "/root/fontra-download/public-html/"
+      - name: Download Windows Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: "Fontra Pak Windows"
+          path: ./downloaded-artifacts
+
+      - name: Upload Artifacts to Remote Host
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+          username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+          password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+          port: 22
+          source: ./downloaded-artifacts/*.zip
+          target: "/root/fontra-download/public-html/"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Unzip macOS Artifact
         run: |
-          unzip -q ./downloaded-artifact-macos/*.zip -d ./downloaded-artifact-macos
+          unzip -q "./downloaded-artifact-macos/Fontra Pak macOS.zip" -d ./downloaded-artifact-macos
 
       - name: Upload macOS Artifact to Remote Host
         uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -153,6 +153,9 @@ jobs:
           port: 22
           source: "./downloaded-artifact/FontraPak.dmg"
           target: "/root/fontra-download/public-html/"
+          debug: true
+          overwrite: true
+          use_insecure_cipher: true
 
   upload-windows-exe:
     runs-on: ubuntu-latest
@@ -179,3 +182,6 @@ jobs:
           port: 22
           source: "./downloaded-artifact/FontraPak.zip"
           target: "/root/fontra-download/public-html/"
+          debug: true
+          overwrite: true
+          use_insecure_cipher: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -133,43 +133,48 @@ jobs:
           name: Fontra Pak Windows
           path: ./dist/*.exe
 
-  upload:
+  upload-macos-app:
     runs-on: ubuntu-latest
-    needs: [build-macos-app, build-windows-exe]
+    needs: [build-macos-app]
     steps:
 
-      - name: Download macOS Artifact
+      - name: Retrieve Artifact
         uses: actions/download-artifact@v2
         with:
           name: "Fontra Pak macOS"
-          path: ./downloaded-artifacts-macos
+          path: ./downloaded-artifact
 
-      - name: Unzip macOS Artifact
+      - name: Unzip Artifact
         run: |
-          unzip -q "./downloaded-artifact-macos/Fontra Pak macOS.zip" -d ./downloaded-artifact-macos
+          unzip -q "./downloaded-artifact/Fontra Pak macOS.zip" -d ./downloaded-artifact
 
-      - name: Upload macOS Artifact to Remote Host
+      - name: Upload Artifact
         uses: appleboy/scp-action@v0.1.4
         with:
           host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
           username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
           password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
           port: 22
-          source: "./downloaded-artifacts-macos/Fontra Pak macOS.dmg"
+          source: "./downloaded-artifact/Fontra Pak macOS.dmg"
           target: "/root/fontra-download/public-html/"
 
-      - name: Download Windows Artifact
+  upload-windows-exe:
+    runs-on: ubuntu-latest
+    needs: [build-windows-exe]
+    steps:
+
+      - name: Retrieve Artifact
         uses: actions/download-artifact@v2
         with:
           name: "Fontra Pak Windows"
-          path: ./downloaded-artifacts-windows
+          path: ./downloaded-artifact
 
-      - name: Upload Windows Artifact to Remote Host
+      - name: Upload Artifact
         uses: appleboy/scp-action@v0.1.4
         with:
           host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
           username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
           password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
           port: 22
-          source: "./downloaded-artifacts-windows/Fontra Pak Windows.zip"
+          source: "./downloaded-artifact/Fontra Pak Windows.zip"
           target: "/root/fontra-download/public-html/"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -144,11 +144,10 @@ jobs:
           path: ./dist/*.exe
 
       - name: Zip Windows Artifacts
-        run: |
-          cp ./dist/*.exe zip_temp/
-          exe_basename=$(basename ./dist/*.exe)
-          zip -r "$exe_basename.zip" zip_temp/
-          rm -rf zip_temp
+        uses: vimtor/action-zip@v1.1
+        with:
+          files: ./dist/Fontra Pak Windows.exe
+          dest: "Fontra Pak Windows.zip"
 
       - name: Upload Windows Artifacts
         uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -144,14 +144,10 @@ jobs:
           name: "Fontra Pak macOS"
           path: ./downloaded-artifact
 
-      - name: Debug Artifact
-        run: |
-          ls -l
-          ls -l ./downloaded-artifact
-
-      - name: Unzip Artifact
-        run: |
-          unzip -q "./downloaded-artifact/Fontra Pak macOS.zip" -d ./downloaded-artifact
+      # - name: Debug Artifact
+      #   run: |
+      #     ls -l
+      #     ls -l ./downloaded-artifact
 
       - name: Upload Artifact
         uses: appleboy/scp-action@v0.1.4
@@ -160,7 +156,7 @@ jobs:
           username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
           password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
           port: 22
-          source: "./downloaded-artifact/Fontra Pak macOS.dmg"
+          source: "./downloaded-artifact/FontraPak.dmg"
           target: "/root/fontra-download/public-html/"
 
   upload-windows-exe:
@@ -174,10 +170,15 @@ jobs:
           name: "Fontra Pak Windows"
           path: ./downloaded-artifact
 
-      - name: Debug Artifact
+      # - name: Debug Artifact
+      #   run: |
+      #     ls -l
+      #     ls -l ./downloaded-artifact
+
+      - name: Zip Artifact
         run: |
-          ls -l
-          ls -l ./downloaded-artifact
+          cd ./downloaded-artifact
+          zip -q FontraPak.zip "Fontra Pak.exe"
 
       - name: Upload Artifact
         uses: appleboy/scp-action@v0.1.4
@@ -186,5 +187,5 @@ jobs:
           username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
           password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
           port: 22
-          source: "./downloaded-artifact/Fontra Pak Windows.zip"
+          source: "./downloaded-artifact/FontraPak.zip"
           target: "/root/fontra-download/public-html/"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -142,20 +142,30 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: "Fontra Pak macOS"
-          path: ./downloaded-artifacts
+          path: ./downloaded-artifacts-macos
 
-      - name: Download Windows Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: "Fontra Pak Windows"
-          path: ./downloaded-artifacts
-
-      - name: Upload Artifacts to Remote Host
+      - name: Upload macOS Artifact to Remote Host
         uses: appleboy/scp-action@v0.1.4
         with:
           host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
           username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
           password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
           port: 22
-          source: ./downloaded-artifacts/*.zip
+          source: "./downloaded-artifacts-macos/Fontra Pak macOS.zip"
+          target: "/root/fontra-download/public-html/"
+
+      - name: Download Windows Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: "Fontra Pak Windows"
+          path: ./downloaded-artifacts-windows
+
+      - name: Upload Windows Artifact to Remote Host
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.FONTRA_DOWNLOAD_HOST }}
+          username: ${{ secrets.FONTRA_DOWNLOAD_USERNAME }}
+          password: ${{ secrets.FONTRA_DOWNLOAD_PASSWORD }}
+          port: 22
+          source: "./downloaded-artifacts-windows/Fontra Pak Windows.zip"
           target: "/root/fontra-download/public-html/"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -144,11 +144,6 @@ jobs:
           name: "Fontra Pak macOS"
           path: ./downloaded-artifact
 
-      # - name: Debug Artifact
-      #   run: |
-      #     ls -l
-      #     ls -l ./downloaded-artifact
-
       - name: Upload Artifact
         uses: appleboy/scp-action@v0.1.4
         with:
@@ -169,11 +164,6 @@ jobs:
         with:
           name: "Fontra Pak Windows"
           path: ./downloaded-artifact
-
-      # - name: Debug Artifact
-      #   run: |
-      #     ls -l
-      #     ls -l ./downloaded-artifact
 
       - name: Zip Artifact
         run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -110,7 +110,6 @@ jobs:
           port: 22
           source: "./dist/*.dmg"
           target: "/root/fontra-download/public-html/"
-        working-directory: ${{ github.workspace }}
 
   build-windows-exe:
     runs-on: windows-latest
@@ -150,7 +149,6 @@ jobs:
           exe_basename=$(basename ./dist/*.exe)
           zip -r "$exe_basename.zip" zip_temp/
           rm -rf zip_temp
-        working-directory: ${{ github.workspace }}
 
       - name: Upload Windows Artifacts
         uses: appleboy/scp-action@v0.1.4
@@ -161,4 +159,3 @@ jobs:
           port: 22
           source: "./dist/*.zip"
           target: "/root/fontra-download/public-html/"
-        working-directory: ${{ github.workspace }}


### PR DESCRIPTION
Fix #55
This PR updates the app workflow for uploading the macOS and Windows applications to a remote server via SCP.

- I added two new steps to the app workflow: `upload-macos-app` and `upload-windows-exe` 
- In each step I retrieve the artifact and I upload it via SCP to the remote server.
- Retrieving the artifact is a bit redundant, but unfortunately it has not been possible to enqueue the upload step at the end of each build step because the `appleboy/scp-action` need to run on a Linux machine.
- I run each `upload` step when its parent `build` step is completed.

---

Here the the successful workflow run: 
https://github.com/googlefonts/fontra-pak/actions/runs/6480369328

Here the direct links for downloading the app:
- macOS: https://fontra-download.black-foundry.com/FontraPak.dmg
- Windows: https://fontra-download.black-foundry.com/FontraPak.zip