### PR TITLE
Fix macos app drop types

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -136,7 +136,7 @@ jobs:
   upload-to-download-server:
     runs-on: ubuntu-latest
     needs: [build-macos-app, build-windows-exe]
-    if: github.ref == "refs/heads/main"
+    if: github.ref == 'refs/heads/main'
 
     steps:
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -136,6 +136,8 @@ jobs:
   upload-to-download-server:
     runs-on: ubuntu-latest
     needs: [build-macos-app, build-windows-exe]
+    if: github.ref == "refs/heads/main"
+
     steps:
 
       - name: Retrieve Artifact

--- a/FontraPak.spec
+++ b/FontraPak.spec
@@ -77,7 +77,14 @@ if sys.platform == "darwin":
         info_plist={
             "CFBundleDocumentTypes": [
                 dict(
-                    CFBundleTypeExtensions=["ttf", "otf", "designspace", "ufo"],
+                    CFBundleTypeExtensions=[
+                        "ttf",
+                        "otf",
+                        "designspace",
+                        "ufo",
+                        "fontra",
+                        "rcjk",
+                    ],
                     CFBundleTypeRole="Editor",
                 ),
             ],

--- a/FontraPak.spec
+++ b/FontraPak.spec
@@ -82,6 +82,7 @@ if sys.platform == "darwin":
                         "otf",
                         "designspace",
                         "ufo",
+                        "glyphs",
                         "fontra",
                         "rcjk",
                     ],

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -51,7 +51,7 @@ mainText = """
 Your fonts will stay on your computer and will not be uploaded anywhere.
 <br>
 <br>
-Fontra Pak reads and writes .ufo and .designspace
+Fontra Pak reads and writes .ufo, .designspace, .rcjk and .fontra
 <br>
 Additionally, it can read (not write) .ttf, .otf, and (with some limitations)
 .glyphs and .glyphspackage


### PR DESCRIPTION
This fixes #66.

It also ensures that we don't upload from PR branch GHA runs.