### PR TITLE
Fix unreliable entry_point() plugin finding by adding selected package meta data

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-macos-app:
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
       - name: macOS Notarize -- Install Certificates

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-macos-app:
-    runs-on: macOS-latest
+    runs-on: macos-14
 
     steps:
       - name: macOS Notarize -- Install Certificates

--- a/FontraPak.spec
+++ b/FontraPak.spec
@@ -1,6 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 import sys
-from PyInstaller.utils.hooks import collect_all
+from importlib.metadata import PackageNotFoundError
+from PyInstaller.utils.hooks import collect_all, copy_metadata
 
 datas = []
 binaries = []
@@ -18,6 +19,10 @@ for module_name in modules_to_collect_all:
     datas += tmp_ret[0]
     binaries += tmp_ret[1]
     hiddenimports += tmp_ret[2]
+    try:
+        datas += copy_metadata(module_name)
+    except PackageNotFoundError:
+        print("no metadata for", module_name)
 
 
 block_cipher = None

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -7,6 +7,7 @@ import secrets
 import signal
 import sys
 import webbrowser
+from importlib.metadata import entry_points
 from urllib.parse import quote
 
 from fontra import __version__ as fontraVersion
@@ -227,6 +228,9 @@ def runFontraServer(port):
 
 
 def main():
+    for e in entry_points(group="fontra.filesystem.backends"):
+        print("-", e.name)
+
     port = findFreeTCPPort()
     serverProcess = multiprocessing.Process(target=runFontraServer, args=(port,))
     serverProcess.start()

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -7,7 +7,6 @@ import secrets
 import signal
 import sys
 import webbrowser
-from importlib.metadata import entry_points
 from urllib.parse import quote
 
 from fontra import __version__ as fontraVersion
@@ -228,9 +227,6 @@ def runFontraServer(port):
 
 
 def main():
-    for e in entry_points(group="fontra.filesystem.backends"):
-        print("-", e.name)
-
     port = findFreeTCPPort()
     serverProcess = multiprocessing.Process(target=runFontraServer, args=(port,))
     serverProcess.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ git+https://github.com/googlefonts/fontra.git
 git+https://github.com/googlefonts/fontra-rcjk.git
 git+https://github.com/googlefonts/fontra-glyphs.git
 aiohttp==3.9.3
-pyinstaller==5.13.2
+pyinstaller==6.5.0
 # PyQt6 6.5.0 does not support macOS 10.15 anymore, so for now
 # we'll stick to these:
 PyQt6==6.4.2


### PR DESCRIPTION
My conclusion is that we were previously lucky that somehow the entry_points did work, and with PyInstaller only Silicon, but not in Intel. This PR makes it explicit that we include the metadata for the modules that provide entry points, and this indeed seems to make the entry_points() work again.

This fixes #62.