### PR TITLE
Universal2 build

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           curl https://www.python.org/ftp/python/3.12.3/python-3.12.3-macos11.pkg --output python-installer.pkg
           sudo installer -pkg python-installer.pkg -target /
+          # Somehow using plain "python3" gives us the runner's homebrew Python,
+          # so let's be explicit about the path:
           ourpython=/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12
           ls -l $ourpython
           $ourpython --version

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,7 +35,7 @@ jobs:
         # We use Python from python.org instead of from actions/setup-python, as the app
         # built with the latter does not work on macOS 10.15
         run: |
-          curl https://www.python.org/ftp/python/3.12.3/python-3.12.3-macos11.pkg --output python-installer.pkg
+          curl https://www.python.org/ftp/python/3.12.7/python-3.12.7-macos11.pkg --output python-installer.pkg
           sudo installer -pkg python-installer.pkg -target /
           # Somehow using plain "python3" gives us the runner's homebrew Python,
           # so let's be explicit about the path:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,15 +37,14 @@ jobs:
         run: |
           curl https://www.python.org/ftp/python/3.12.3/python-3.12.3-macos11.pkg --output python-installer.pkg
           sudo installer -pkg python-installer.pkg -target /
-          which python3
-          which python3.12
-          python3.12 --version
-          python3.12 -c "import platform; print('platform:', platform.platform())"
-          python3.12 -c "import platform; print('macOS version:', platform.mac_ver()[0])"
+          ls -l /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12
+          /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 --version
+          /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -c "import platform; print('platform:', platform.platform())"
+          /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -c "import platform; print('macOS version:', platform.mac_ver()[0])"
 
       - name: Setup Virtual Environment
         run: |
-          python3.12 -m venv venv
+          /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m venv venv
           source venv/bin/activate
           python -c "import sys; print('\n'.join(sys.path))"
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,14 +37,12 @@ jobs:
         run: |
           curl https://www.python.org/ftp/python/3.12.3/python-3.12.3-macos11.pkg --output python-installer.pkg
           sudo installer -pkg python-installer.pkg -target /
-          ls -l /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12
-          /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 --version
-          /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -c "import platform; print('platform:', platform.platform())"
-          /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -c "import platform; print('macOS version:', platform.mac_ver()[0])"
-
-      - name: Setup Virtual Environment
-        run: |
-          /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m venv venv
+          ourpython=/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12
+          ls -l $ourpython
+          $ourpython --version
+          $ourpython -c "import platform; print('platform:', platform.platform())"
+          $ourpython -c "import platform; print('macOS version:', platform.mac_ver()[0])"
+          $ourpython -m venv venv
           source venv/bin/activate
           python -c "import sys; print('\n'.join(sys.path))"
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.10 for macOS
+      - name: Set up Python 3.12 for macOS
         # We use Python from python.org instead of from actions/setup-python, as the app
         # built with the latter does not work on macOS 10.15
         run: |
-          curl https://www.python.org/ftp/python/3.10.9/python-3.10.9-macos11.pkg --output python-installer.pkg
+          curl https://www.python.org/ftp/python/3.12.3/python-3.12.3-macos11.pkg --output python-installer.pkg
           sudo installer -pkg python-installer.pkg -target /
           python3 --version
           python3 -c "import platform; print('macOS version:', platform.mac_ver()[0])"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,7 +50,9 @@ jobs:
         run: |
           source venv/bin/activate
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt | tee pip_log.txt
+          python macos/ensure_universal_wheels.py pip_log.txt
+          pip install --force build/universal_wheels/*.whl
           pip install -r requirements-dev.txt
 
       - name: Run pre-commit

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,12 +37,15 @@ jobs:
         run: |
           curl https://www.python.org/ftp/python/3.12.3/python-3.12.3-macos11.pkg --output python-installer.pkg
           sudo installer -pkg python-installer.pkg -target /
-          python3 --version
-          python3 -c "import platform; print('macOS version:', platform.mac_ver()[0])"
+          which python3
+          which python3.12
+          python3.12 --version
+          python3.12 -c "import platform; print('platform:', platform.platform())"
+          python3.12 -c "import platform; print('macOS version:', platform.mac_ver()[0])"
 
       - name: Setup Virtual Environment
         run: |
-          python3 -m venv venv
+          python3.12 -m venv venv
           source venv/bin/activate
           python -c "import sys; print('\n'.join(sys.path))"
 

--- a/FontraPak.spec
+++ b/FontraPak.spec
@@ -59,7 +59,7 @@ if sys.platform == "darwin":
         console=False,
         disable_windowed_traceback=False,
         argv_emulation=False,
-        target_arch=None,
+        target_arch="universal2",
         codesign_identity=None,
         entitlements_file=None,
         icon="icon/FontraIcon.ico",

--- a/macos/build_dmg.py
+++ b/macos/build_dmg.py
@@ -28,7 +28,7 @@ with tempfile.TemporaryDirectory() as imgPath:
                 "-fs",
                 "HFS+",
                 "-size",
-                "200m",
+                "300m",
                 "-srcfolder",
                 imgPath,
                 "-volname",

--- a/macos/ensure_universal_wheels.py
+++ b/macos/ensure_universal_wheels.py
@@ -122,7 +122,7 @@ def main():
                 for file_descriptor in data["urls"]
                 if file_descriptor["python_version"] in python_versions_sort_map
             ],
-            lambda file_descriptor: python_versions_sort_map[
+            key=lambda file_descriptor: python_versions_sort_map[
                 file_descriptor["python_version"]
             ],
         )

--- a/macos/ensure_universal_wheels.py
+++ b/macos/ensure_universal_wheels.py
@@ -1,0 +1,138 @@
+import argparse
+import json
+import pathlib
+import re
+import sys
+from tempfile import TemporaryDirectory
+from urllib.request import urlopen
+
+from delocate.fuse import fuse_wheels
+from packaging.utils import parse_wheel_filename
+
+#
+# The problem we are trying to solve is:
+# - To build a universal2 app with py2app, we need _all_ compiled packages to be universal2
+# - This is hard for two reasons:
+#   - Not all packages offer universal2 wheels
+#   - When running on x86, pip will serve x86, even if universal2 is available
+#
+# We take the following approach:
+# - Run `pip install -r requirements.txt` and capture the output
+# - Find and parse all wheel filenames
+# - Any wheel that is x86 or arm64 needs attention (eg. we ignore "any" and "universal2"):
+#   - Check the pypi json for the package + version
+#   - If there is a universal2 wheel, download it, write to `build/universal_wheels/*.whl`
+#   - Else if there are x86 and arm64 wheels, download both and merge, write to
+#     `build/universal_wheels/*.whl`
+#   - Else: error
+# - `pip install --force build/universal_wheels/*.whl`
+#
+
+python_versions = {f"cp{sys.version_info.major}{sys.version_info.minor}", "py3"}
+
+
+class IncompatibleWheelError(Exception):
+    pass
+
+
+def url_filename(url):
+    return url.rsplit("/", 1)[-1]
+
+
+def download_file(url, dest_dir):
+    filename = url_filename(url)
+    print("downloading wheel", filename)
+    response = urlopen(url)
+    with open(dest_dir / filename, "wb") as f:
+        f.write(response.read())
+
+
+def merge_wheels(url1, url2, dest_dir):
+    wheel_name1 = url_filename(url1)
+    wheel_name2 = url_filename(url2)
+    print("merging wheels", wheel_name1, "and", wheel_name2)
+
+    with TemporaryDirectory() as tmpdir:
+        tmpdir = pathlib.Path(tmpdir)
+
+        download_file(url1, tmpdir)
+        download_file(url2, tmpdir)
+
+        wheel_names = [wheel_name1, wheel_name2]
+        wheel_names.sort()
+
+        assert any("x86" in name for name in wheel_names)
+        assert any("arm64" in name for name in wheel_names)
+
+        package, version, build, tags = parse_wheel_filename(wheel_names[0])
+
+        wheel_base, platform = wheel_names[0].rsplit("-", 1)
+        platform_base_parts = platform.split("_")
+        platform_base = "_".join(platform_base_parts[:3])
+
+        universal_wheel_path = (
+            dest_dir / f"{wheel_base.lower()}-{platform_base}_universal2.whl"
+        )
+        print("writing universal wheel", universal_wheel_path.name)
+        fuse_wheels(tmpdir / wheel_name1, tmpdir / wheel_name2, universal_wheel_path)
+
+
+wheel_filename_pattern = re.compile(r"[^\s=]+.whl")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pip_log")
+    parser.add_argument("--wheels-dir", default="build/universal_wheels")
+
+    args = parser.parse_args()
+
+    wheels_dir = pathlib.Path(args.wheels_dir).resolve()
+    wheels_dir.mkdir(exist_ok=True, parents=True)
+
+    pip_log_path = args.pip_log
+    with open(pip_log_path) as f:
+        pip_log = f.read()
+
+    non_portable_wheels = {}
+
+    for wheel_filename in wheel_filename_pattern.findall(pip_log):
+        package, version, build, tags = parse_wheel_filename(wheel_filename)
+        package = package.lower()
+        if any("x86" in tag.platform or "arm64" in tag.platform for tag in tags):
+            assert non_portable_wheels.get(package, wheel_filename) == wheel_filename
+            non_portable_wheels[package] = wheel_filename
+
+    for wheel_filename in non_portable_wheels.values():
+        package, version, build, tags = parse_wheel_filename(wheel_filename)
+        response = urlopen(f"https://pypi.org/pypi/{package}/{version}/json")
+        data = json.load(response)
+
+        universal_wheels = []
+        platform_wheels = []
+
+        for file_descriptor in data["urls"]:
+            if file_descriptor["python_version"] not in python_versions:
+                continue
+            wheel_filename = file_descriptor["filename"]
+            package, version, build, tags = parse_wheel_filename(wheel_filename)
+            if any("macosx" in tag.platform for tag in tags):
+                if any("universal2" in tag.platform for tag in tags):
+                    universal_wheels.append(file_descriptor["url"])
+                else:
+                    platform_wheels.append(file_descriptor["url"])
+
+        if universal_wheels:
+            assert len(universal_wheels) == 1
+            download_file(universal_wheels[0], wheels_dir)
+        elif platform_wheels:
+            assert len(platform_wheels) == 2
+            merge_wheels(platform_wheels[0], platform_wheels[1], wheels_dir)
+        else:
+            raise IncompatibleWheelError(
+                f"No universal2 solution found for non-portable wheel {wheel_filename}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/macos/ensure_universal_wheels.py
+++ b/macos/ensure_universal_wheels.py
@@ -11,7 +11,8 @@ from packaging.utils import parse_wheel_filename
 
 #
 # The problem we are trying to solve is:
-# - To build a universal2 app with py2app, we need _all_ compiled packages to be universal2
+# - To build a universal2 app with py2app or PyInstaller, we need _all_ compiled packages
+#   to be universal2
 # - This is hard for two reasons:
 #   - Not all packages offer universal2 wheels
 #   - When running on x86, pip will serve x86, even if universal2 is available

--- a/macos/ensure_universal_wheels.py
+++ b/macos/ensure_universal_wheels.py
@@ -32,8 +32,8 @@ from packaging.utils import parse_wheel_filename
 python_versions = [
     f"cp{sys.version_info.major}{minor}"
     for minor in range(8, sys.version_info.minor + 1)
-] + ["py3"]
-python_versions_sort_map = {v: i for i, v in enumerate(python_versions)}
+]
+python_versions.reverse()
 
 
 class IncompatibleWheelError(Exception):
@@ -116,19 +116,23 @@ def main():
         universal_wheels = []
         platform_wheels = []
 
-        file_descriptors = sorted(
-            [
+        for python_version in python_versions:
+            file_descriptors = [
                 file_descriptor
                 for file_descriptor in data["urls"]
-                if file_descriptor["python_version"] in python_versions_sort_map
-            ],
-            key=lambda file_descriptor: python_versions_sort_map[
-                file_descriptor["python_version"]
-            ],
-        )
+                if file_descriptor["python_version"] == python_version
+            ]
+            if file_descriptors:
+                break
 
-        if file_descriptors:
-            file_descriptor = file_descriptors[-1]
+        if not file_descriptors:
+            file_descriptors = [
+                file_descriptor
+                for file_descriptor in data["urls"]
+                if file_descriptor["python_version"] == "py3"
+            ]
+
+        for file_descriptor in file_descriptors:
             wheel_filename = file_descriptor["filename"]
             package, version, build, tags = parse_wheel_filename(wheel_filename)
             if any("macosx" in tag.platform for tag in tags):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 git+https://github.com/googlefonts/fontra.git
 git+https://github.com/googlefonts/fontra-rcjk.git
 git+https://github.com/googlefonts/fontra-glyphs.git
-aiohttp
-pyinstaller
-PyQt6
-PyQt6-Qt6
-PyQt6-sip
-delocate
+aiohttp==3.9.5
+pyinstaller==6.6.0
+PyQt6==6.7.0
+PyQt6-Qt6==6.7.0
+PyQt6-sip==13.6.0
+delocate==0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 git+https://github.com/googlefonts/fontra.git
 git+https://github.com/googlefonts/fontra-rcjk.git
 git+https://github.com/googlefonts/fontra-glyphs.git
-aiohttp==3.9.4
-pyinstaller==6.5.0
-# PyQt6 6.5.0 does not support macOS 10.15 anymore, so for now
-# we'll stick to these:
-PyQt6==6.4.2
-PyQt6-Qt6==6.4.3
-PyQt6-sip==13.5.0  # 13.6.0 works, but issues a DeprecationWarning that makes our test fail
+aiohttp
+pyinstaller
+PyQt6
+PyQt6-Qt6
+PyQt6-sip
+delocate

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ PyQt6==6.7.1
 PyQt6-Qt6==6.7.3
 PyQt6-sip==13.8.0
 delocate==0.12.0
+# Use patched fork to work around https://github.com/matthew-brett/delocate/issues/228
+git+https://github.com/justvanrossum/delocate.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pyinstaller==6.10.0
 PyQt6==6.7.1
 PyQt6-Qt6==6.7.3
 PyQt6-sip==13.8.0
-delocate==0.12.0
 # Use patched fork to work around https://github.com/matthew-brett/delocate/issues/228
 git+https://github.com/justvanrossum/delocate.git
+# delocate==0.12.0


### PR DESCRIPTION
This upgrades the Python version to 3.12.7, and upgrades all dependencies, and changes the build to output a universal2 app, that runs natively on Intel and Apple Silicon.

Fixes #107. This also fixes #85.