### PR TITLE
Issue128

### DIFF
--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -170,10 +170,14 @@ class FontraMainWidget(QMainWindow):
         event.acceptProposedAction()
 
     def newFont(self):
+        activeFolder = self.settings.value("activeFolder", os.path.expanduser("~"))
+        if not os.path.isdir(activeFolder):
+            activeFolder = os.path.expanduser("~")
+
         fontPath, fileType = QFileDialog.getSaveFileName(
             self,
             "New Font...",
-            "Untitled",
+            os.path.join(activeFolder, "Untitled"),
             ";;".join(fileTypesMapping),
         )
 
@@ -182,6 +186,8 @@ class FontraMainWidget(QMainWindow):
             return
 
         fontPath = getFontPath(fontPath, fileType)
+
+        self.settings.setValue("activeFolder", os.path.dirname(fontPath))
 
         # Create a new empty project on disk
         try:

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -20,6 +20,7 @@ from PyQt6.QtWidgets import (
     QFileDialog,
     QLabel,
     QMainWindow,
+    QMessageBox,
     QPlainTextEdit,
     QPushButton,
     QSizePolicy,
@@ -183,7 +184,13 @@ class FontraMainWidget(QMainWindow):
         fontPath = getFontPath(fontPath, fileType)
 
         # Create a new empty project on disk
-        asyncio.run(createNewFont(fontPath))
+        try:
+            asyncio.run(createNewFont(fontPath))
+        except Exception as e:
+            showMessageDialog(
+                "The new font could not be saved", repr(e), QMessageBox.Icon.Warning
+            )
+            return
 
         if os.path.exists(fontPath):
             textboxValue = self.textBox.toPlainText()
@@ -207,6 +214,15 @@ def openFile(path, port, sampleText="Hello"):
 
     urlFragment = dumpURLFragment({"text": sampleText})
     webbrowser.open(f"http://localhost:{port}/editor/-/{path}{urlFragment}")
+
+
+def showMessageDialog(message, infoText, icon=None):
+    dialog = QMessageBox()
+    if icon is not None:
+        dialog.setIcon(icon)
+    dialog.setText(message)
+    dialog.setInformativeText(infoText)
+    dialog.exec()
 
 
 def runFontraServer(port):


### PR DESCRIPTION
This fixes #128:
- don't silently fail if the new font can't be saved, but show a dialog
- default to user's home dir when showing save dialog, and remember the chosen folder