### PR TITLE
Add "link to documentation" button

### DIFF
--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -40,7 +40,6 @@ from PyQt6.QtWidgets import (
     QProgressDialog,
     QPushButton,
     QSizePolicy,
-    QVBoxLayout,
     QWidget,
 )
 

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -41,6 +41,7 @@ from PyQt6.QtWidgets import (
     QSizePolicy,
     QVBoxLayout,
     QWidget,
+    QGridLayout,
 )
 
 commonCSS = """
@@ -149,14 +150,23 @@ class FontraMainWidget(QMainWindow):
         )
         self.label.setWordWrap(True)
 
-        layout = QVBoxLayout()
+        layout = QGridLayout()  # Helpful: https://www.pythontutorial.net/pyqt/pyqt-qgridlayout/
 
         button = QPushButton("&New Font...", self)
         button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         button.clicked.connect(self.newFont)
 
-        layout.addWidget(button)
-        layout.addWidget(self.label)
+        buttonDocs = QPushButton("&?", self)
+        buttonDocs.setToolTip('Opens the <b>documentation</b>')
+        buttonDocs.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        buttonDocs.clicked.connect(lambda: webbrowser.open('http://docs.fontra.xyz'))
+
+        layout.addWidget(button, 0, 0,
+                         alignment=Qt.AlignmentFlag.AlignLeft)
+        layout.addWidget(buttonDocs, 0, 1,
+                         alignment=Qt.AlignmentFlag.AlignRight)
+
+        layout.addWidget(self.label, 1, 0, 1, 2)
 
         self.textBox = QPlainTextEdit(self.settings.value("sampleText", "Hello"), self)
         self.textBox.setFixedHeight(50)
@@ -164,9 +174,9 @@ class FontraMainWidget(QMainWindow):
         self.textBox.textChanged.connect(
             lambda: self.settings.setValue("sampleText", self.textBox.toPlainText())
         )
-        layout.addWidget(QLabel("Initial sample text:"))
-        layout.addWidget(self.textBox)
-        layout.addWidget(QLabel(f"Fontra version {fontraVersion}"))
+        layout.addWidget(QLabel("Initial sample text:"), 2, 0)
+        layout.addWidget(self.textBox, 3, 0, 1, 2)
+        layout.addWidget(QLabel(f"Fontra version {fontraVersion}"), 4, 0)
 
         widget = QWidget()
         widget.setLayout(layout)

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -157,7 +157,7 @@ class FontraMainWidget(QMainWindow):
         button.clicked.connect(self.newFont)
 
         buttonDocs = QPushButton("?", self)
-        buttonDocs.setToolTip('Opens the <b>documentation</b>')
+        buttonDocs.setToolTip('Link to <b>documentation</b>')
         buttonDocs.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         buttonDocs.clicked.connect(lambda: webbrowser.open('http://docs.fontra.xyz'))
 

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -32,6 +32,7 @@ from PyQt6.QtCore import (
 from PyQt6.QtWidgets import (
     QApplication,
     QFileDialog,
+    QGridLayout,
     QLabel,
     QMainWindow,
     QMessageBox,
@@ -41,7 +42,6 @@ from PyQt6.QtWidgets import (
     QSizePolicy,
     QVBoxLayout,
     QWidget,
-    QGridLayout,
 )
 
 commonCSS = """
@@ -150,21 +150,21 @@ class FontraMainWidget(QMainWindow):
         )
         self.label.setWordWrap(True)
 
-        layout = QGridLayout()  # Helpful: https://www.pythontutorial.net/pyqt/pyqt-qgridlayout/
+        layout = (
+            QGridLayout()
+        )  # Helpful: https://www.pythontutorial.net/pyqt/pyqt-qgridlayout/
 
         button = QPushButton("&New Font...", self)
         button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         button.clicked.connect(self.newFont)
 
         buttonDocs = QPushButton("?", self)
-        buttonDocs.setToolTip('Link to <b>documentation</b>')
+        buttonDocs.setToolTip("Link to <b>documentation</b>")
         buttonDocs.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        buttonDocs.clicked.connect(lambda: webbrowser.open('http://docs.fontra.xyz'))
+        buttonDocs.clicked.connect(lambda: webbrowser.open("http://docs.fontra.xyz"))
 
-        layout.addWidget(button, 0, 0,
-                         alignment=Qt.AlignmentFlag.AlignLeft)
-        layout.addWidget(buttonDocs, 0, 1,
-                         alignment=Qt.AlignmentFlag.AlignRight)
+        layout.addWidget(button, 0, 0, alignment=Qt.AlignmentFlag.AlignLeft)
+        layout.addWidget(buttonDocs, 0, 1, alignment=Qt.AlignmentFlag.AlignRight)
 
         layout.addWidget(self.label, 1, 0, 1, 2)
 

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -156,7 +156,7 @@ class FontraMainWidget(QMainWindow):
         button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         button.clicked.connect(self.newFont)
 
-        buttonDocs = QPushButton("&?", self)
+        buttonDocs = QPushButton("?", self)
         buttonDocs.setToolTip('Opens the <b>documentation</b>')
         buttonDocs.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         buttonDocs.clicked.connect(lambda: webbrowser.open('http://docs.fontra.xyz'))

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -160,7 +160,7 @@ class FontraMainWidget(QMainWindow):
         buttonDocs = QPushButton("?", self)
         buttonDocs.setToolTip("Link to <b>documentation</b>")
         buttonDocs.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        buttonDocs.clicked.connect(lambda: webbrowser.open("http://docs.fontra.xyz"))
+        buttonDocs.clicked.connect(lambda: webbrowser.open("https://docs.fontra.xyz"))
 
         layout.addWidget(button, 0, 0, alignment=Qt.AlignmentFlag.AlignLeft)
         layout.addWidget(buttonDocs, 0, 1, alignment=Qt.AlignmentFlag.AlignRight)

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -149,9 +149,8 @@ class FontraMainWidget(QMainWindow):
         )
         self.label.setWordWrap(True)
 
-        layout = (
-            QGridLayout()
-        )  # Helpful: https://www.pythontutorial.net/pyqt/pyqt-qgridlayout/
+        # Helpful: https://www.pythontutorial.net/pyqt/pyqt-qgridlayout/
+        layout = QGridLayout()
 
         button = QPushButton("&New Font...", self)
         button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -157,7 +157,7 @@ class FontraMainWidget(QMainWindow):
         button.clicked.connect(self.newFont)
 
         buttonDocs = QPushButton("?", self)
-        buttonDocs.setToolTip("Link to <b>documentation</b>")
+        buttonDocs.setToolTip("Open documentation website")
         buttonDocs.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         buttonDocs.clicked.connect(lambda: webbrowser.open("https://docs.fontra.xyz"))
 


### PR DESCRIPTION
Fixes #142 

This is how it looks like (including a tooltip):
<img width="732" alt="Screenshot 2024-12-06 at 06 01 08" src="https://github.com/user-attachments/assets/a2cf4ad0-310b-48f6-a0a2-ac2e2580190b">
