### PR TITLE
Fix lingering processes on shutdown and PyInstaller failing to remove its temporary directory

### DIFF
--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -553,8 +553,12 @@ def main():
     def cleanup():
         queue.put(None)
         thread.join()
-        os.kill(serverProcess.pid, signal.SIGINT)
-        serverProcess.join(timeout=1)
+        process = psutil.Process(serverProcess.pid)
+        for p in [process] + process.children(recursive=True):
+            if sys.platform != "win32":
+                p.send_signal(psutil.signal.SIGINT)
+            else:
+                p.terminate()
 
     app.aboutToQuit.connect(cleanup)
 

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -3,6 +3,7 @@ import logging
 import multiprocessing
 import os
 import pathlib
+import psutil
 import secrets
 import signal
 import sys

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -554,6 +554,7 @@ def main():
         queue.put(None)
         thread.join()
         os.kill(serverProcess.pid, signal.SIGINT)
+        serverProcess.join(timeout=1)
 
     app.aboutToQuit.connect(cleanup)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ PyQt6-sip==13.10.2
 # Use patched fork to work around https://github.com/matthew-brett/delocate/issues/228
 git+https://github.com/justvanrossum/delocate.git
 # delocate==0.12.0
+psutil==7.0.0


### PR DESCRIPTION
This change resolves an issue where subprocesses would linger after shutdown, particularly on Windows, preventing PyInstaller from removing its temporary directory.

We now use `psutil` to recursively terminate the process tree on all platforms. On Windows, we call `terminate()` on each process; elsewhere, we send `SIGINT`, similar to the original `os.kill()` behavior.

Note: `psutil` is cross-platform and now fully replaces `os.kill()` to support recursive cleanup. This was necessary on Windows and is potentially beneficial elsewhere, though only Windows was tested.

This appears to be the most robust solution. Both `onedir` and `onefile` builds revealed lingering processes after shutdown. The difference is that `onefile` unpacks to a temporary directory, making the issue more visible, as PyInstaller will emit a warning if cleanup fails.